### PR TITLE
Added github actions to easier create new releases

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,134 @@
+name: Build skin-composer and publish artifacts
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  jar:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+
+    - name: Fix gradlew file permissions
+      run: chmod +x gradlew
+
+    - name: Build jar
+      run: ./gradlew desktop:dist
+
+    - name: Upload jar artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposer.jar
+        path: desktop/build/lib/SkinComposer.jar
+
+
+  linux-deb-rpm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+
+    - name: Fix gradlew file permissions
+      run: chmod +x gradlew
+
+    - name: Build deb/rpm
+      run: ./gradlew desktop:jpackage
+
+    - name: Fix deb filename
+      run: mv desktop/build/jpackage/*.deb SkinComposer.deb
+
+    - name: Fix rpm filename
+      run: mv desktop/build/jpackage/*.rpm SkinComposer.rpm
+
+    - name: Upload deb artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposer.deb
+        path: SkinComposer.deb
+
+    - name: Upload rpm artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposer.rpm
+        path: SkinComposer.rpm
+
+
+
+
+  windows-msi-exe:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+
+    - name: Install dependencies
+      run: choco install -y winrar
+
+    - name: Build exe
+      run: ./gradlew.bat installer:jpackageZip
+
+    - name: Upload exe artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposerInstaller.exe
+        path: installer\build\winrar\SkinComposerInstaller.exe
+
+
+  apple-app-dmg-pkg:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 14
+      uses: actions/setup-java@v1
+      with:
+        java-version: 14
+
+    - name: Fix gradlew file permissions
+      run: chmod +x gradlew
+
+    - name: Build app/dmg/pkg
+      run: ./gradlew desktop:jpackage
+
+    - name: Fix app filename
+      run: mv desktop/build/jpackage/*.app SkinComposer.app
+
+    - name: Fix dmg filename
+      run: mv desktop/build/jpackage/*.dmg SkinComposer.dmg
+
+    - name: Fix pkg filename
+      run: mv desktop/build/jpackage/*.pkg SkinComposer.pkg
+
+    - name: Upload app artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposer.app
+        path: SkinComposer.app
+
+    - name: Upload dmg artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposer.dmg
+        path: SkinComposer.dmg
+
+    - name: Upload pkg artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SkinComposer.pkg
+        path: SkinComposer.pkg

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ project(":core") {
         compile "com.github.raeleus.TenPatch:tenpatch:5.0.0"
         implementation "space.earlygrey:shapedrawer:2.2.0"
         compile 'com.squareup:javapoet:1.12.1'
-        compile 'com.ray3k.stripe:stripe:0.0.1-SNAPSHOT'
+        compile 'com.github.raeleus:stripe:master-SNAPSHOT'
     }
 }
 


### PR DESCRIPTION
Hey!

As mentioned in the discord I've setup a github action which builds all possible formats:

* Universal:
  * JAR
* Windows:
  * EXE
* Linux:
  * DEB
  * RPM
* Apple:
  * APP
  * PKG
  * DMG

Additionally I needed to upgrade stripe to the jitpack version since maven wasn't able to find it.

---

It only starts a build when you commit to master or merge to master.

You can find the artifacts by clicking on the "Actions" button, then selecting the latest workflow and that should show you everything.

Sadly github automatically bundles everything into zip files, oh well.