### PR TITLE
Fix for colors in Free Type Fonts dialog

### DIFF
--- a/core/src/com/ray3k/skincomposer/dialog/DialogFreeTypeFont.java
+++ b/core/src/com/ray3k/skincomposer/dialog/DialogFreeTypeFont.java
@@ -698,6 +698,9 @@ public class DialogFreeTypeFont extends Dialog {
                 }, null);
             }
         });
+        if (data.color != null) {
+            textButton.setUserObject(jsonData.getColorByName(data.color));
+        }
         
         bottom.row();
         label = new Label("Gamma:", skin);
@@ -804,6 +807,9 @@ public class DialogFreeTypeFont extends Dialog {
                 }, null);
             }
         });
+        if (data.borderColor != null) {
+            textButton.setUserObject(jsonData.getColorByName(data.borderColor));
+        }
         
         bottom.row();
         label = new Label("Border Straight:", skin);
@@ -933,6 +939,9 @@ public class DialogFreeTypeFont extends Dialog {
                 }, null);
             }
         });
+        if (data.shadowColor != null) {
+            textButton.setUserObject(jsonData.getColorByName(data.shadowColor));
+        }
         
         label = new Label("Incremental:", skin);
         bottom.add(label).right();


### PR DESCRIPTION
During inital setup, ColorData in buttons is not set so updateColors clears them when one changes. 