### PR TITLE
new setting allows switching between full-path and filename-only view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Skin Composer Version 43 ###
 * Preview text adapts to available glyphs in Fonts Dialog.
 * Prevent users from selecting a parent listed further down the styles list which would cause an error when loaded in game. Resolves #90
+* Added setting to allow showing the full path in the Recent Files menu (Thanks Grisgram). Resolves #92
 
 ### Skin Composer Version 42 ###
 * Fixed NPE when loading a project with a place holder FreeType font.

--- a/core/src/com/ray3k/skincomposer/data/ProjectData.java
+++ b/core/src/com/ray3k/skincomposer/data/ProjectData.java
@@ -134,7 +134,7 @@ public class ProjectData implements Json.Serializable {
             FileHandle file = new FileHandle(path);
             RecentFile recentFile = new RecentFile();
             recentFile.fileHandle = file;
-            recentFile.name = file.nameWithoutExtension();
+            recentFile.name = isFullPathInRecentFiles() ? file.path() : file.nameWithoutExtension();
             if (file.exists()) {
                 returnValue.add(recentFile);
             }
@@ -275,7 +275,7 @@ public class ProjectData implements Json.Serializable {
         newProject = false;
         String title = "Skin Composer";
         if (saveFile != null && saveFile.exists()) {
-            title += " - " + saveFile.nameWithoutExtension();
+            title += " - " + (isFullPathInRecentFiles() ? saveFile.path() : saveFile.nameWithoutExtension());
             if (!changesSaved) {
                 title += "*";
             }
@@ -779,7 +779,15 @@ public class ProjectData implements Json.Serializable {
     public void setPreviewBgColor(Color color) {
         preferences.put("preview-bg-color", color);
     }
-    
+
+    public boolean isFullPathInRecentFiles() {
+        return (boolean) preferences.get("recent-fullpath", false);
+    }
+
+    public void setFullPathInRecentFiles(boolean fullPath) {
+        preferences.put("recent-fullpath", fullPath);
+    }
+
     /**
      * Returns true if file exists and depending on the state of relative resources
      * and save file state.

--- a/core/src/com/ray3k/skincomposer/data/ProjectData.java
+++ b/core/src/com/ray3k/skincomposer/data/ProjectData.java
@@ -781,11 +781,12 @@ public class ProjectData implements Json.Serializable {
     }
 
     public boolean isFullPathInRecentFiles() {
-        return (boolean) preferences.get("recent-fullpath", false);
+        return generalPref.getBoolean("recent-fullpath", false);
     }
 
     public void setFullPathInRecentFiles(boolean fullPath) {
-        preferences.put("recent-fullpath", fullPath);
+        generalPref.putBoolean("recent-fullpath", fullPath);
+        generalPref.flush();
     }
 
     /**

--- a/core/src/com/ray3k/skincomposer/dialog/PopSettings.java
+++ b/core/src/com/ray3k/skincomposer/dialog/PopSettings.java
@@ -23,6 +23,7 @@ public class PopSettings extends PopTable {
     private boolean resourcesRelative;
     private boolean allowingWelcome;
     private boolean exportWarnings;
+    private boolean recentFullPath;
     private boolean allowingUpdates;
     
     public PopSettings() {
@@ -37,6 +38,7 @@ public class PopSettings extends PopTable {
         resourcesRelative = projectData.areResourcesRelative();
         allowingWelcome = projectData.isAllowingWelcome();
         exportWarnings = projectData.isShowingExportWarnings();
+        recentFullPath = projectData.isFullPathInRecentFiles();
         allowingUpdates = projectData.isCheckingForUpdates();
         
         populate();
@@ -264,6 +266,18 @@ public class PopSettings extends PopTable {
         table.add(exportWarningsCheckBox);
         
         table.row();
+        var fullPathCheckBox = new ImageTextButton("Show full path in recent files", getSkin(), "checkbox");
+        fullPathCheckBox.setChecked(recentFullPath);
+        fullPathCheckBox.addListener(handListener);
+        fullPathCheckBox.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeListener.ChangeEvent event, Actor actor) {
+                recentFullPath = fullPathCheckBox.isChecked();
+            }
+        });
+        table.add(fullPathCheckBox);
+
+        table.row();
         var updatesCheckBox = new ImageTextButton("Check for updates?", getSkin(), "checkbox");
         updatesCheckBox.setChecked(allowingUpdates);
         updatesCheckBox.addListener(handListener);
@@ -313,6 +327,7 @@ public class PopSettings extends PopTable {
         projectData.setAllowingWelcome(allowingWelcome);
         projectData.setUiScale(uiScale);
         projectData.setShowingExportWarnings(exportWarnings);
+        projectData.setFullPathInRecentFiles(recentFullPath);
         projectData.setCheckingForUpdates(allowingUpdates);
         undoableManager.clearUndoables();
     
@@ -322,7 +337,8 @@ public class PopSettings extends PopTable {
             Main.newVersion = Main.VERSION;
             rootTable.fire(new RootTable.RootTableEvent(RootTable.RootTableEnum.CHECK_FOR_UPDATES_COMPLETE));
         }
-    
+        Main.rootTable.updateRecentFiles();
+
         hide();
     }
     


### PR DESCRIPTION
solves issue#91
if activated, recent files and main window header bar show the full path of the currently open file.
if disabled (the default), everything is at is has been before

![image](https://user-images.githubusercontent.com/19487451/105373441-fbdc2580-5c06-11eb-9cee-53203139124c.png)
