### PR TITLE
FreeType placeholder NPE fix

### DIFF
--- a/core/src/com/ray3k/skincomposer/data/ProjectData.java
+++ b/core/src/com/ray3k/skincomposer/data/ProjectData.java
@@ -539,13 +539,13 @@ public class ProjectData implements Json.Serializable {
             FileHandle targetFolder = saveFile.sibling(saveFile.nameWithoutExtension() + "_data/");
             
             for (var font : jsonData.getFreeTypeFonts()) {
-                if (font.file == null && font.useCustomSerializer) {
-                    errors.add(font);
-                } else {
+                if (font.file != null) {
                     FileHandle localFile = targetFolder.child(font.file.name());
                     if (!localFile.exists()) {
                         errors.add(font);
                     }
+                } else if (font.useCustomSerializer) {
+                    errors.add(font);
                 }
             }
         }


### PR DESCRIPTION
The fix for #88 introduced a code path that bypassed the existing null check, causing line 545 of ProjectData to throw a NPE during skin loading with placeholders, so this reverses the if-else statement to prevent that. 