### PR TITLE
Add arm64 support to work on macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ project(":core") {
         compile "org.lwjgl:lwjgl-nfd:3.3.1:natives-windows"
         compile "org.lwjgl:lwjgl-nfd:3.3.1:natives-linux"
         compile "org.lwjgl:lwjgl-nfd:3.3.1:natives-macos"
+        compile "org.lwjgl:lwjgl-nfd:3.3.1:natives-macos-arm64"
         compile "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
         compile ("com.badlogicgames.gdx:gdx-tools:$gdxVersion") {

--- a/core/src/com/ray3k/skincomposer/data/JsonData.java
+++ b/core/src/com/ray3k/skincomposer/data/JsonData.java
@@ -121,7 +121,6 @@ public class JsonData implements Json.Serializable {
             projectData.getAtlasData().readAtlas(atlasHandle);
         } else {
             warnings.add("[RED]ERROR:[] Atlas file [BLACK]" + atlasHandle.name() + "[] does not exist.");
-            return warnings;
         }
 
         //folder for critical files to be copied to


### PR DESCRIPTION
SkinComposer.jar is missing macos/arm64/org/lwjgl/nfd/liblwjgl_nfd.dylib

```
[LWJGL] Failed to load a library. Possible solutions:
	a) Add the directory that contains the shared library to -Djava.library.path or -Dorg.lwjgl.librarypath.
	b) Add the JAR that contains the shared library to the classpath.
[LWJGL] Enable debug mode with -Dorg.lwjgl.util.Debug=true for better diagnostics.
[LWJGL] Enable the SharedLibraryLoader debug mode with -Dorg.lwjgl.util.DebugLoader=true for better diagnostics.
com.badlogic.gdx.utils.GdxRuntimeException: java.lang.UnsatisfiedLinkError: Failed to locate library: liblwjgl_nfd.dylib
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:172)
	at com.ray3k.skincomposer.desktop.DesktopLauncher.main(DesktopLauncher.java:484)
Caused by: java.lang.UnsatisfiedLinkError: Failed to locate library: liblwjgl_nfd.dylib
	at org.lwjgl.system.Library.loadSystem(Library.java:164)
	at org.lwjgl.util.nfd.LibNFD.<clinit>(LibNFD.java:17)
	at org.lwjgl.util.nfd.NativeFileDialog.<clinit>(NativeFileDialog.java:65)
	at com.ray3k.skincomposer.desktop.DesktopLauncher.openDialog(DesktopLauncher.java:273)
	at com.ray3k.skincomposer.dialog.DialogImport.showFileBrowser(DialogImport.java:240)
	at com.ray3k.skincomposer.dialog.DialogImport$2.changed(DialogImport.java:117)
	at com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.handle(ChangeListener.java:28)
	at com.badlogic.gdx.scenes.scene2d.Actor.notify(Actor.java:188)
	at com.badlogic.gdx.scenes.scene2d.Actor.fire(Actor.java:152)
	at com.badlogic.gdx.scenes.scene2d.ui.Button.setChecked(Button.java:125)
	at com.badlogic.gdx.scenes.scene2d.ui.Button$1.clicked(Button.java:93)
	at com.badlogic.gdx.scenes.scene2d.utils.ClickListener.touchUp(ClickListener.java:88)
	at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:71)
	at com.badlogic.gdx.scenes.scene2d.Stage.touchUp(Stage.java:355)
	at com.badlogic.gdx.InputEventQueue.drain(InputEventQueue.java:70)
	at com.badlogic.gdx.backends.lwjgl3.DefaultLwjgl3Input.update(DefaultLwjgl3Input.java:189)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:378)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:192)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:166)
	... 1 more
```