### PR TITLE
Fix floating number parsing

### DIFF
--- a/core/src/com/ray3k/skincomposer/dialog/textratypist/PopTextraEffects.java
+++ b/core/src/com/ray3k/skincomposer/dialog/textratypist/PopTextraEffects.java
@@ -1,5 +1,6 @@
 package com.ray3k.skincomposer.dialog.textratypist;
 
+import java.util.Locale;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.Event;
@@ -920,7 +921,7 @@ public class PopTextraEffects extends PopTable {
         var label = new Label(name, skin, "tt");
         subTable.add(label);
         
-        var textField = new TextField(String.format("%.1f", defaultValue), skin, "tt") {
+        var textField = new TextField(String.format(Locale.US, "%.1f", defaultValue), skin, "tt") {
             @Override
             public void next(boolean up) {
                 stage.setKeyboardFocus(findActor(up?previousField:nextField));
@@ -939,7 +940,8 @@ public class PopTextraEffects extends PopTable {
         buttonTable.add(imageButton);
         imageButton.addListener(handListener);
         onChange(imageButton, () -> {
-            if (textField.getText().length() > 0) textField.setText(String.format("%.1f", Float.parseFloat(textField.getText()) + .1f));
+            if (textField.getText().length() > 0) textField.setText(
+                    String.format(Locale.US, "%.1f", Float.parseFloat(textField.getText()) + .1f));
             textField.fire(new ChangeEvent());
         });
     
@@ -948,7 +950,8 @@ public class PopTextraEffects extends PopTable {
         buttonTable.add(imageButton);
         imageButton.addListener(handListener);
         onChange(imageButton, () -> {
-            if (textField.getText().length() > 0) textField.setText(String.format("%.1f", Float.parseFloat(textField.getText()) - .1f));
+            if (textField.getText().length() > 0) textField.setText(
+                    String.format(Locale.US, "%.1f", Float.parseFloat(textField.getText()) - .1f));
             textField.fire(new ChangeEvent());
         });
         


### PR DESCRIPTION
Fix for floating number representation for Locales which have floating point character different then '.'

Just added US locale when using String.format method in order to get floating point representation with '.' delimiter (required for default floating point parser)

Fix for #125 